### PR TITLE
fix: added graceful message when search is not enabled on the cluster

### DIFF
--- a/src/controller/actionHandler.tsx
+++ b/src/controller/actionHandler.tsx
@@ -26,7 +26,6 @@ import HTTPClient from './HTTPClient'
 import lodash from 'lodash'
 import strings from '../util/i18n'
 import { DELETE_RESOURCE, DELETE_QUERY, SAVED_SEARCH_QUERY } from '../definitions/search-queries'
-import { setPluginState } from '../pluginState'
 import { renderSearchAvailable } from './search'
 
 export const deleteSavedSearch = args =>
@@ -60,14 +59,12 @@ export const deleteSavedSearch = args =>
                 resolve(resp.errors[0])
               }
             })
-            .catch(err => {
-              setPluginState('error', err)
+            .catch(() => {
               resolve(renderSearchAvailable())
             })
         }
       })
-      .catch(err => {
-        setPluginState('error', err)
+      .catch(() => {
         resolve(renderSearchAvailable())
       })
   })
@@ -92,7 +89,6 @@ export const deleteResource = args =>
         }
       })
       .catch(err => {
-        setPluginState('error', err)
         resolve(renderSearchAvailable())
       })
   })

--- a/src/controller/savedSearch.tsx
+++ b/src/controller/savedSearch.tsx
@@ -60,7 +60,6 @@ export const doSavedSearch = args =>
         resolve(data.items.length > 0 ? buildTable(data) : resourceNotFound())
       })
       .catch(err => {
-        setPluginState('error', err)
         resolve(renderSearchAvailable())
       })
   })

--- a/src/controller/search.tsx
+++ b/src/controller/search.tsx
@@ -21,18 +21,20 @@ import { usage } from './helpfiles/searchhelp'
 import { SEARCH_RELATED_QUERY } from '../definitions/search-queries'
 import { getSidecar } from './sidecar'
 import strings from '../util/i18n'
-import { getPluginState, setPluginState, resourceNotFound } from '../pluginState'
+import { getPluginState, resourceNotFound } from '../pluginState'
 import Modal from '../components/Modal'
 import { searchDelete } from './actionHandler'
+import * as lodash from 'lodash'
 
-export const renderSearchAvailable = () => {
+export const renderSearchAvailable = (err?) => {
   const node = document.createElement('div')
   node.classList.add('is-search-available')
+
   const status = () => {
     return (
       <div>
         <p>
-          <span className="oops">{strings('search.service.installed.error')}</span>
+          <span className="oops">{err ? err : strings('search.service.installed.error')}</span>
         </p>
       </div>
     )
@@ -82,10 +84,13 @@ export const doSearch = (args): any | NavResponse => {
 
     HTTPClient('post', 'search', SEARCH_RELATED_QUERY(userQuery.keywords, userQuery.filters))
       .then(res => {
+        const err = lodash.get(res, 'errors[0].message')
+        if (err) {
+          resolve(renderSearchAvailable(err))
+        }
         resolve(buildTable(res.data.searchResult[0]))
       })
-      .catch(err => {
-        setPluginState('error', err)
+      .catch((err) => {
         resolve(renderSearchAvailable())
       })
   })

--- a/src/controller/sidecar.tsx
+++ b/src/controller/sidecar.tsx
@@ -81,7 +81,13 @@ export const getSidecar = async args =>
     }
 
     HTTPClient('post', 'search', SEARCH_RELATED_QUERY(userQuery.keywords, userQuery.filters))
-      .then(res => {
+      .then((res) => {
+        const err =  lodash.get(res, 'errors[0].message', '')
+
+        if (err) {
+          resolve(renderSearchAvailable(err))
+        }
+
         const data = lodash.get(res, 'data.searchResult[0]', '')
         const kind = lodash.get(data, 'items[0].kind', '')
 
@@ -106,14 +112,12 @@ export const getSidecar = async args =>
 
               resolve(buildSidecar('resource', data, resource, command))
             })
-            .catch(err => {
-              setPluginState('error', err)
+            .catch(() => {
               resolve(renderSearchAvailable())
             })
         }
       })
-      .catch(err => {
-        setPluginState('error', err)
+      .catch(() => {
         resolve(renderSearchAvailable())
       })
   })

--- a/src/pluginState.ts
+++ b/src/pluginState.ts
@@ -15,7 +15,6 @@ import strings from './util/i18n'
 
 const state = {
   default: ['cluster', 'kind', 'label', 'name', 'namespace', 'status'],
-  error: undefined,
   flags: ['-h', '--h', '-help', '--help'],
   searchSchema: [],
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -39,9 +39,6 @@ const registerCapability: CapabilityRegistration = async () => {
     .then(resp => {
       setPluginState('searchSchema', lodash.get(resp, 'data.searchSchema.allProperties', ''))
     })
-    .catch(err => {
-      setPluginState('error', err)
-    })
 }
 
 export default registerCapability

--- a/src/views/modes/related.tsx
+++ b/src/views/modes/related.tsx
@@ -24,7 +24,8 @@ import { getCurrentTab, doEval } from '@kui-shell/core'
 import strings from '../../util/i18n'
 
 const handleEvent = (resource: any, event?: any) => {
-  const clusters = lodash.get(resource, 'items', '').map((res) => res.cluster)
+  var clusters = lodash.get(resource, 'items', '').map((res) => res.cluster)
+  clusters = clusters.filter((c, index) => clusters.indexOf(c) === index)
 
   if ((event && event.which === 13) || !event) {
     let command = `search kind:${lodash.get(resource, 'kind', '')} `

--- a/tests/jest/controller/search.test.js
+++ b/tests/jest/controller/search.test.js
@@ -50,11 +50,6 @@ describe('Search plugin state', () => {
     expect(pluginState.getPluginState().searchSchema).toMatchSnapshot()
   })
 
-  it('should set the error value', () => {
-    pluginState.setPluginState('error', 'Error: Connection timeout')
-    expect(pluginState.getPluginState().error).toMatchSnapshot()
-  })
-
   it('should get an updated plugin state', () => {
     expect(pluginState.getPluginState()).toMatchSnapshot()
   })
@@ -76,30 +71,6 @@ describe('Rendering search available', () => {
   const _  = search.renderSearchAvailable(true, undefined)
 
   expect(spy).toBeCalled()
-
-  it('should render that search is installed', () => {
-    pluginState.setPluginState('enabled', true)
-    pluginState.setPluginState('error', undefined)
-    expect(search.renderSearchAvailable(pluginState.getPluginState().enabled, pluginState.getPluginState().error)).toMatchSnapshot()
-  })
-
-  it('should render that search is installed, but is not available', () => {
-    pluginState.setPluginState('enabled', true)
-    pluginState.setPluginState('error', 'Error: Connection timeout')
-    expect(search.renderSearchAvailable(pluginState.getPluginState().enabled, pluginState.getPluginState().error)).toMatchSnapshot()
-  })
-
-  it('should render that search is not installed', () => {
-    pluginState.setPluginState('enabled', false)
-    pluginState.setPluginState('error', undefined)
-    expect(search.renderSearchAvailable(pluginState.getPluginState().enabled, pluginState.getPluginState().error)).toMatchSnapshot()
-  })
-
-  it('should render that there was an issue checking if search was installed', () => {
-    pluginState.setPluginState('enabled', false)
-    pluginState.setPluginState('error', 'Error: Connection timeout')
-    expect(search.renderSearchAvailable(pluginState.getPluginState().enabled, pluginState.getPluginState().error)).toMatchSnapshot()
-  })
 })
 
 describe('Search command', () => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/12439. This PR will add the graceful message: `The search service is not enabled in the current configuration.`, when search is not enabled within the cluster.

Minor changes for: https://github.com/open-cluster-management/backlog/issues/13061